### PR TITLE
Upgrade upload-pages-artifact from v3 to v4 to fix duplicate artifact failures

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: deploy
 


### PR DESCRIPTION
## Summary

- Upgrades `actions/upload-pages-artifact` from v3 to v4 in the GitHub Pages deployment workflow
- Fixes the "Multiple artifacts named github-pages were unexpectedly found" error that failed [this run](https://github.com/altendky/mujou/actions/runs/21806683041/job/62911131331)

## Context

v3 has a [known bug](https://github.com/actions/upload-pages-artifact/issues/97) where retry handling during the "Finalizing artifact upload" stage can create duplicate artifacts with the same name, causing `actions/deploy-pages` to fail. The failed run produced 3 identical `github-pages` artifacts within 13 seconds.

v4 pins to a newer SHA of `actions/upload-artifact` with improved retry handling. The only behavior change in v4 is that dotfiles are excluded from the artifact, which does not affect this workflow.