### PR TITLE
Unify title styling between static page and app

### DIFF
--- a/crates/mujou/src/main.rs
+++ b/crates/mujou/src/main.rs
@@ -96,6 +96,15 @@ fn app() -> Element {
         // Theme toggle logic — copied from site/theme-toggle.js by build.rs.
         script { dangerous_inner_html: include_str!(env!("THEME_TOGGLE_JS_PATH")) }
 
+        // Google Fonts — Noto Sans (Latin) and Noto Sans JP for the title
+        // wordmark.  See follow-up issue to self-host for offline/privacy.
+        link { rel: "preconnect", href: "https://fonts.googleapis.com" }
+        link { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "anonymous" }
+        link {
+            rel: "stylesheet",
+            href: "https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&family=Noto+Sans+JP:wght@400&display=swap",
+        }
+
         div { class: "min-h-screen bg-(--bg) text-(--text) flex flex-col",
             // Theme toggle (fixed-positioned via shared theme.css;
             // content injected by shared theme-toggle.js)
@@ -106,7 +115,7 @@ fn app() -> Element {
 
             // Header
             header { class: "px-6 py-4 border-b border-(--border)",
-                h1 { class: "text-2xl font-bold", "mujou" }
+                h1 { class: "text-2xl title-brand", "mujou" }
                 p { class: "text-(--muted) text-sm",
                     "Image to vector path converter for sand tables and CNC devices"
                 }

--- a/site/index.html
+++ b/site/index.html
@@ -6,6 +6,9 @@
     <title>mujou</title>
     <script src="theme-detect.js"></script>
     <link rel="stylesheet" href="theme.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&family=Noto+Sans+JP:wght@400&display=swap" rel="stylesheet">
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       body {
@@ -23,14 +26,10 @@
       }
       h1 {
         font-size: 4rem;
-        font-weight: 300;
-        letter-spacing: 0.2em;
         margin-bottom: 0.5rem;
       }
       .japanese {
         font-size: 4rem;
-        font-weight: 300;
-        letter-spacing: 0.1em;
         margin-bottom: 0.5rem;
       }
       p {
@@ -57,8 +56,8 @@
   </head>
   <body>
     <main>
-      <h1>mujou</h1>
-      <div class="japanese">諸行無常</div>
+      <h1 class="title-brand">mujou</h1>
+      <div class="japanese title-brand-jp">諸行無常</div>
       <p>all things are impermanent</p>
       <hr>
       <p>images to sand table paths</p>

--- a/site/theme.css
+++ b/site/theme.css
@@ -7,6 +7,18 @@
  */
 
 :root {
+  /* -- Title / wordmark typography --
+     Shared between the static landing page and the Dioxus app so the
+     "mujou" wordmark and Japanese subtitle render identically in both
+     contexts.  Only *size* should differ (hero vs. in-app header).
+     Font loaded from Google Fonts CDN; see follow-up issue to
+     self-host the .woff2 files for offline/privacy. */
+  --title-font: 'Noto Sans', sans-serif;
+  --title-font-jp: 'Noto Sans JP', 'Noto Sans', sans-serif;
+  --title-weight: 400;
+  --title-spacing: 0.2em;
+  --title-spacing-jp: 0.1em;
+
   /* -- Light palette (default) -- */
   --bg: #fafafa;
   --text: #1a1a1a;
@@ -100,4 +112,18 @@
 .theme-toggle:focus-visible {
   outline: 2px solid var(--border-accent);
   outline-offset: 2px;
+}
+
+/* Title wordmark — reusable classes for the "mujou" brand text.
+   Size is intentionally omitted so each context can set its own. */
+.title-brand {
+  font-family: var(--title-font);
+  font-weight: var(--title-weight);
+  letter-spacing: var(--title-spacing);
+}
+
+.title-brand-jp {
+  font-family: var(--title-font-jp);
+  font-weight: var(--title-weight);
+  letter-spacing: var(--title-spacing-jp);
 }


### PR DESCRIPTION
## Summary

- Define shared CSS custom properties and reusable `.title-brand` / `.title-brand-jp` classes in `theme.css` so the "mujou" wordmark and Japanese subtitle render identically in both the static landing page and the Dioxus app
- Use Noto Sans (Latin) and Noto Sans JP (Japanese) at weight 400, loaded from Google Fonts CDN
- Font size remains intentionally different between contexts (4rem hero vs. text-2xl header)

## Changes

| File | Description |
|------|-------------|
| `site/theme.css` | Add `--title-font`, `--title-font-jp`, `--title-weight`, `--title-spacing`, `--title-spacing-jp` custom properties + `.title-brand` / `.title-brand-jp` classes |
| `site/index.html` | Add Google Fonts `<link>` tags, apply new classes to `<h1>` and Japanese text, remove redundant inline font-weight/letter-spacing |
| `crates/mujou/src/main.rs` | Add Google Fonts `<link>` elements, replace `font-bold` with `title-brand` class on header h1 |

## Before / After

| Property | Before (static page) | Before (app) | After (both) |
|----------|---------------------|--------------|--------------|
| Font family | `system-ui` | Tailwind default | Noto Sans / Noto Sans JP |
| Font weight | 300 | 700 | 400 |
| Letter spacing | 0.2em | normal | 0.2em |
| Font size | 4rem | text-2xl | unchanged (intentionally different) |

## Follow-up

A follow-up issue will be created to self-host the font files as `.woff2` for offline support and privacy (no third-party CDN requests).

Closes #15