### PR TITLE
Add production-like local preview script

### DIFF
--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -59,7 +59,9 @@ if [ "$SKIP_BUILD" = false ]; then
 
 	# Static landing page
 	cp -r "$ROOT/site/"* "$PREVIEW_DIR/"
-	sed -i "s|{{REPO_URL}}|${REPO_URL}|g" "$PREVIEW_DIR/index.html"
+	# Use a temp file for portability (BSD sed on macOS requires different -i syntax)
+	sed "s|{{REPO_URL}}|${REPO_URL}|g" "$PREVIEW_DIR/index.html" >"$PREVIEW_DIR/index.html.tmp"
+	mv "$PREVIEW_DIR/index.html.tmp" "$PREVIEW_DIR/index.html"
 
 	# Dioxus WASM app
 	cp -r "$ROOT/target/dx/mujou/release/web/public/"* "$PREVIEW_DIR/app/"


### PR DESCRIPTION
## Summary

- Add `scripts/preview.sh` that builds the WASM app and serves a full production-like preview locally, mirroring the GitHub Pages deployment structure (landing page at `/`, app at `/app/`)

## Usage

```bash
./scripts/preview.sh              # build and serve on port 8000
./scripts/preview.sh --port 9000  # custom port
./scripts/preview.sh --skip-build # re-serve previous build without rebuilding
```

## Details

The script:
1. Runs `dx bundle --release --package mujou --platform web --base-path app`
2. Assembles `target/preview/` with the same layout as the deploy workflow
3. Replaces the `{{REPO_URL}}` placeholder in the landing page
4. Serves via `python3 -m http.server` bound to `127.0.0.1`

This replicates what `.github/workflows/deploy-github-pages.yml` does, making it easy to verify the full site locally before pushing.