### PR TITLE
Set workspace resolver = "3" to match edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]


### PR DESCRIPTION
## Summary

- Adds `resolver = "3"` to the `[workspace]` table in root `Cargo.toml` to match the `edition = "2024"` setting and eliminate the Cargo warning about defaulting to resolver 1.

Closes #58