### PR TITLE
Fix export panel overflow at narrow viewport widths

### DIFF
--- a/crates/mujou/src/main.rs
+++ b/crates/mujou/src/main.rs
@@ -246,7 +246,7 @@ fn app() -> Element {
             href: "https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&family=Noto+Sans+JP:wght@400&display=swap",
         }
 
-        div { class: "min-h-screen bg-(--bg) text-(--text) flex flex-col",
+        div { class: "min-h-screen bg-(--bg) text-(--text) flex flex-col overflow-x-hidden",
             // Theme toggle (fixed-positioned via shared theme.css;
             // content injected by shared theme-toggle.js)
             button {
@@ -267,9 +267,9 @@ fn app() -> Element {
             }
 
             // Main content area
-            div { class: "flex-1 flex flex-col lg:flex-row gap-6 p-6",
+            div { class: "flex-1 flex flex-col lg:flex-row gap-6 p-6 min-w-0",
                 // Left column: Preview + Filmstrip + Controls
-                div { class: "flex-1 flex flex-col gap-4",
+                div { class: "flex-1 flex flex-col gap-4 min-w-0",
 
                     // Show results (stale or fresh) when available.
                     // The processing indicator overlays rather than replaces.
@@ -366,7 +366,7 @@ fn app() -> Element {
                 }
 
                 // Right sidebar: Export (desktop only)
-                div { class: "hidden lg:block lg:w-72 flex-shrink-0",
+                div { class: "hidden lg:block lg:w-72 shrink-0",
                     ExportPanel {
                         result: result(),
                         filename: filename(),


### PR DESCRIPTION
## Summary

- Add `min-w-0` to the main content row and left column flex containers so they shrink below their content's intrinsic minimum width, preventing the fixed-width export sidebar from overflowing the viewport
- Add `overflow-x-hidden` to the page root as a safety net against horizontal scroll
- Use the shorter `shrink-0` Tailwind alias on the sidebar (equivalent to `flex-shrink-0`)

## Problem

At viewport widths between ~1024px and ~1400px, the export panel (SVG, THR, G-code, DXF, PNG buttons) overflowed the right edge of the viewport, requiring horizontal scrolling. The "Export" heading and buttons were partially or fully clipped.

## Root cause

CSS flexbox items default to `min-width: auto`, which resolves to `min-content`. This prevents a `flex: 1` child from shrinking below the intrinsic width of its content (e.g. the filmstrip's non-wrapping thumbnail row or the SVG preview). Combined with the sidebar's `flex-shrink-0` at a fixed 288px width and 48px of padding, the total exceeded the viewport width.

## Verified at

- 1024px (lg breakpoint boundary)
- 1280px (original problem width)
- 1600px (wide, no regression)