### PR TITLE
Move circular mask step before path joining in pipeline

### DIFF
--- a/crates/mujou-io/src/components/filmstrip.rs
+++ b/crates/mujou-io/src/components/filmstrip.rs
@@ -112,9 +112,10 @@ fn render_thumbnail(result: &WorkerResult, stage: StageId, is_dark: bool) -> Ele
             render_img_thumb(url, "Edges thumbnail")
         }
 
-        StageId::Contours | StageId::Simplified => {
+        StageId::Contours | StageId::Simplified | StageId::Masked => {
             let polylines = match stage {
                 StageId::Contours => &result.contours,
+                StageId::Masked => result.masked.as_deref().unwrap_or(&result.simplified),
                 _ => &result.simplified,
             };
             let w = result.dimensions.width;
@@ -135,11 +136,8 @@ fn render_thumbnail(result: &WorkerResult, stage: StageId, is_dark: bool) -> Ele
             }
         }
 
-        StageId::Path | StageId::Masked => {
-            let polyline = match stage {
-                StageId::Masked => result.final_polyline(),
-                _ => &result.joined,
-            };
+        StageId::Path => {
+            let polyline = &result.joined;
             let w = result.dimensions.width;
             let h = result.dimensions.height;
             let view_box = format!("0 0 {w} {h}");

--- a/crates/mujou-io/src/components/stage_preview.rs
+++ b/crates/mujou-io/src/components/stage_preview.rs
@@ -97,9 +97,10 @@ fn render_raster_edges(result: &WorkerResult, visible: bool, is_dark: bool) -> E
 /// Masked stages. Returns empty for raster stages.
 fn render_vector_preview(result: &WorkerResult, selected: StageId, w: u32, h: u32) -> Element {
     match selected {
-        StageId::Contours | StageId::Simplified => {
+        StageId::Contours | StageId::Simplified | StageId::Masked => {
             let polylines = match selected {
                 StageId::Contours => &result.contours,
+                StageId::Masked => result.masked.as_deref().unwrap_or(&result.simplified),
                 _ => &result.simplified,
             };
             let view_box = format!("0 0 {w} {h}");
@@ -125,11 +126,8 @@ fn render_vector_preview(result: &WorkerResult, selected: StageId, w: u32, h: u3
             }
         }
 
-        StageId::Path | StageId::Masked => {
-            let polyline = match selected {
-                StageId::Masked => result.final_polyline(),
-                _ => &result.joined,
-            };
+        StageId::Path => {
+            let polyline = &result.joined;
             let view_box = format!("0 0 {w} {h}");
             let d = build_path_data(polyline);
 

--- a/crates/mujou-io/src/stage.rs
+++ b/crates/mujou-io/src/stage.rs
@@ -26,10 +26,10 @@ pub enum StageId {
     Contours,
     /// Stage 6: RDP simplification.
     Simplified,
+    /// Stage 7: circular mask.
+    Masked,
     /// Stage 8: path joining.
     Path,
-    /// Stage 9: circular mask.
-    Masked,
 }
 
 impl StageId {
@@ -41,8 +41,8 @@ impl StageId {
         Self::Edges,
         Self::Contours,
         Self::Simplified,
-        Self::Path,
         Self::Masked,
+        Self::Path,
     ];
 
     /// Full display label for the stage.

--- a/crates/mujou-pipeline/src/mask.rs
+++ b/crates/mujou-pipeline/src/mask.rs
@@ -5,7 +5,7 @@
 //! and line segments that cross the boundary are split at the intersection
 //! point on the circle.
 //!
-//! This is step 9 in the pipeline (optional), applied after path joining.
+//! This is step 7 in the pipeline (optional), applied before path joining.
 
 use crate::types::{Point, Polyline};
 

--- a/crates/mujou-worker/src/lib.rs
+++ b/crates/mujou-worker/src/lib.rs
@@ -24,8 +24,8 @@ use wasm_bindgen::prelude::*;
 pub struct VectorResult {
     pub contours: Vec<Polyline>,
     pub simplified: Vec<Polyline>,
+    pub masked: Option<Vec<Polyline>>,
     pub joined: Polyline,
-    pub masked: Option<Polyline>,
     pub dimensions: Dimensions,
 }
 
@@ -170,8 +170,8 @@ fn post_success_response(
     let vector = VectorResult {
         contours: staged.contours.clone(),
         simplified: staged.simplified.clone(),
-        joined: staged.joined.clone(),
         masked: staged.masked.clone(),
+        joined: staged.joined.clone(),
         dimensions: staged.dimensions,
     };
 

--- a/docs/src/project/pipeline.md
+++ b/docs/src/project/pipeline.md
@@ -80,11 +80,23 @@ Otherwise, intermediate points are dropped.
 
 **User parameter:** `simplify_tolerance` (f64, default: 2.0 pixels)
 
-### 7. Path Ordering + Joining
+### 7. Circular Mask (Optional)
+
+For round sand tables (Sisyphus, Oasis Mini), clip all polylines to a circle centered on the image.
+Points outside the circle are removed.
+Polylines that cross the circle boundary are split at the intersection.
+Contours entirely outside the mask are discarded before joining, so the join step only connects surviving contours.
+
+**User parameters:**
+
+- `circular_mask` (bool, default: false)
+- `mask_diameter` (f64, fraction of image width, default: 1.0)
+
+### 8. Path Ordering + Joining
 
 Sand tables cannot lift the ball -- every movement draws a visible line.
 The output must be a **single continuous path**, not a set of disconnected contours.
-This step receives **unordered** contours from simplification and produces a single continuous `Polyline`. Each joining strategy handles its own ordering internally, which allows strategies like Retrace to integrate ordering decisions with backtracking capabilities.
+This step receives contours from masking (if enabled) or simplification, and produces a single continuous `Polyline`. Each joining strategy handles its own ordering internally, which allows strategies like Retrace to integrate ordering decisions with backtracking capabilities.
 
 This is a [pluggable algorithm strategy](principles.md#pluggable-algorithm-strategies) -- the user selects which joining method to use.
 
@@ -126,17 +138,6 @@ For .thr output on circular tables, connect via short spiral arcs in polar coord
 Spirals are the natural visual language of polar sand tables.
 
 **Tradeoffs:** Only applicable to polar output formats. Requires theta-rho space path planning.
-
-### 8. Circular Mask (Optional)
-
-For round sand tables (Sisyphus, Oasis Mini), clip all polylines to a circle centered on the image.
-Points outside the circle are removed.
-Polylines that cross the circle boundary are split at the intersection.
-
-**User parameters:**
-
-- `circular_mask` (bool, default: false)
-- `mask_diameter` (f64, fraction of image width, default: 1.0)
 
 ### 9. Invert (Optional)
 


### PR DESCRIPTION
## Summary

- Reorder the pipeline so the circular mask clips individual polylines **before** path joining (step 7 → mask, step 8 → join), eliminating the double-join and preventing connecting segments from extending outside the mask boundary
- Change `StagedResult::masked` from `Option<Polyline>` to `Option<Vec<Polyline>>` to represent pre-join clipped contours; simplify `final_polyline()` to always return `&self.joined`
- Update filmstrip and stage preview to render the Masked stage as multi-polyline SVG and display it before the Path stage

Closes #61