### PR TITLE
Fix worker WASM init by using object-form wasm_bindgen call

### DIFF
--- a/crates/mujou-io/src/worker.rs
+++ b/crates/mujou-io/src/worker.rs
@@ -384,7 +384,7 @@ self.onmessage = function(e) {{ _msgQueue.push(e); }};
 // Initialize the WASM module from the embedded blob URL.
 // worker_main() (the #[wasm_bindgen(start)] function) runs during
 // instantiation and sets the real onmessage handler on self.
-wasm_bindgen("{wasm_url}")
+wasm_bindgen({{ module_or_path: "{wasm_url}" }})
     .then(function() {{
         // Replay any messages that arrived before initialization.
         var q = _msgQueue;


### PR DESCRIPTION
## Summary

- Fix worker initialization failure by switching from the deprecated string-form `wasm_bindgen(url)` to the object-form `wasm_bindgen({ module_or_path: url })` that current wasm-bindgen expects.

## Details

The generated worker bootstrap script calls `wasm_bindgen()` to initialize the WASM module from a blob URL. The plain string argument form no longer works with the current version of wasm-bindgen. This switches to the object form which is the expected API.

**Changed file:** `crates/mujou-io/src/worker.rs`