### PR TITLE
Fix WASM panic: replace std::time::Instant with web-time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "web-time",
 ]
 
 [[package]]
@@ -2333,6 +2334,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ serde_json = "1"
 # CLI
 clap = { version = "4", features = ["derive"] }
 
+# Cross-platform time (uses performance.now() on WASM)
+web-time = "1"
+
 # Error handling
 thiserror = "2"
 

--- a/crates/mujou-pipeline/Cargo.toml
+++ b/crates/mujou-pipeline/Cargo.toml
@@ -15,6 +15,7 @@ image.workspace = true
 imageproc.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/mujou-pipeline/src/lib.rs
+++ b/crates/mujou-pipeline/src/lib.rs
@@ -79,7 +79,7 @@ pub fn process_staged_with_diagnostics(
         PipelineSummary, StageDiagnostics, StageMetrics, contour_stats, count_edge_pixels,
         total_points,
     };
-    use std::time::Instant;
+    use web_time::Instant;
 
     let pipeline_start = Instant::now();
 


### PR DESCRIPTION
## Summary

- Fixes a panic when running the pipeline in the WASM web worker: `std::time::Instant::now()` is unavailable on `wasm32-unknown-unknown`
- Replaces with `web-time` crate which uses `performance.now()` on WASM and `std::time::Instant` on native

## Details

The diagnostics commit changed `process_staged` to delegate to `process_staged_with_diagnostics`, which uses `Instant::now()` for per-stage timing. This works on native but panics on `wasm32-unknown-unknown` (no system clock), producing an opaque `RuntimeError: unreachable` in the browser console.

The `web-time` crate is a drop-in replacement that detects the platform at compile time.