### PR TITLE
Fix excessive decimal places on settings sliders

### DIFF
--- a/crates/mujou-io/src/components/stage_controls.rs
+++ b/crates/mujou-io/src/components/stage_controls.rs
@@ -115,7 +115,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         0.0,
                         10.0,
                         0.1,
-                        2,
+                        1,
                         move |v: f64| {
                             let mut c = config.clone();
                             #[allow(clippy::cast_possible_truncation)]
@@ -146,7 +146,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         1.0,
                         f64::from(canny_max),
                         1.0,
-                        2,
+                        0,
                         move |v: f64| {
                             let mut c = config_low.clone();
                             #[allow(clippy::cast_possible_truncation)]
@@ -163,7 +163,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         1.0,
                         f64::from(canny_max),
                         1.0,
-                        2,
+                        0,
                         move |v: f64| {
                             let mut c = config_high.clone();
                             #[allow(clippy::cast_possible_truncation)]
@@ -180,7 +180,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         0.0,
                         theoretical_max,
                         1.0,
-                        2,
+                        0,
                         move |v: f64| {
                             let mut c = config_max.clone();
                             #[allow(clippy::cast_possible_truncation)]
@@ -241,7 +241,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         0.0,
                         20.0,
                         0.1,
-                        2,
+                        1,
                         move |v: f64| {
                             let mut c = config.clone();
                             c.simplify_tolerance = v;


### PR DESCRIPTION
## Summary

- Match displayed decimal places to each slider's step size, removing unnecessary trailing zeros
- Blur Sigma and Simplify Tolerance (step 0.1): reduced from 2 to 1 decimal place (e.g. `1.40` → `1.4`)
- Canny Low/High/Max (step 1.0): reduced from 2 to 0 decimal places (e.g. `30.00` → `30`)
- Mask Diameter, Working Resolution, and MST Neighbours were already correct and unchanged