### PR TITLE
fix: update dx CLI version to 0.7.3 to match dioxus dependency

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Dioxus CLI
         uses: taiki-e/install-action@v2
         with:
-          tool: dioxus-cli@0.7.2
+          tool: dioxus-cli@0.7.3
 
       - name: Build WASM app
         run: dx bundle --release --package mujou --platform web --base-path app


### PR DESCRIPTION
## Summary

- Updates `dioxus-cli` from `0.7.2` to `0.7.3` in the deploy workflow to match the resolved `dioxus 0.7.3` dependency in `Cargo.lock`
- Eliminates the `dx and dioxus versions are incompatible!` error during CI builds