### PR TITLE
Add a 'Disabled' option for the downsampling filter

### DIFF
--- a/crates/mujou-bench/src/main.rs
+++ b/crates/mujou-bench/src/main.rs
@@ -101,7 +101,7 @@ enum Joiner {
 #[derive(Clone, Copy, ValueEnum)]
 enum Filter {
     /// Disabled: skip downsampling regardless of image size.
-    None,
+    Disabled,
     /// Nearest-neighbor (fastest, blocky).
     Nearest,
     /// Bilinear interpolation (fast, decent quality).
@@ -117,7 +117,7 @@ enum Filter {
 /// Maps a [`mujou_pipeline::DownsampleFilter`] to the local CLI [`Filter`] enum.
 const fn filter_from_pipeline(f: mujou_pipeline::DownsampleFilter) -> Filter {
     match f {
-        mujou_pipeline::DownsampleFilter::None => Filter::None,
+        mujou_pipeline::DownsampleFilter::Disabled => Filter::Disabled,
         mujou_pipeline::DownsampleFilter::Nearest => Filter::Nearest,
         mujou_pipeline::DownsampleFilter::Triangle => Filter::Triangle,
         mujou_pipeline::DownsampleFilter::CatmullRom => Filter::CatmullRom,
@@ -149,7 +149,7 @@ fn main() -> ExitCode {
         invert: cli.invert,
         working_resolution: cli.working_resolution,
         downsample_filter: match cli.downsample_filter {
-            Filter::None => mujou_pipeline::DownsampleFilter::None,
+            Filter::Disabled => mujou_pipeline::DownsampleFilter::Disabled,
             Filter::Nearest => mujou_pipeline::DownsampleFilter::Nearest,
             Filter::Triangle => mujou_pipeline::DownsampleFilter::Triangle,
             Filter::CatmullRom => mujou_pipeline::DownsampleFilter::CatmullRom,

--- a/crates/mujou-io/src/components/stage_controls.rs
+++ b/crates/mujou-io/src/components/stage_controls.rs
@@ -74,7 +74,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         "downsample_filter",
                         "Downsample Filter",
                         &[
-                            ("None", "None (Disabled)"),
+                            ("Disabled", "Disabled"),
                             ("Nearest", "Nearest"),
                             ("Triangle", "Triangle (Bilinear)"),
                             ("CatmullRom", "CatmullRom (Bicubic)"),
@@ -82,7 +82,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                             ("Lanczos3", "Lanczos3"),
                         ],
                         match config_filter.downsample_filter {
-                            DownsampleFilter::None => "None",
+                            DownsampleFilter::Disabled => "Disabled",
                             DownsampleFilter::Nearest => "Nearest",
                             DownsampleFilter::Triangle => "Triangle",
                             DownsampleFilter::CatmullRom => "CatmullRom",
@@ -92,7 +92,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         move |v: String| {
                             let mut c = config_filter.clone();
                             c.downsample_filter = match v.as_str() {
-                                "None" => DownsampleFilter::None,
+                                "Disabled" => DownsampleFilter::Disabled,
                                 "Nearest" => DownsampleFilter::Nearest,
                                 "CatmullRom" => DownsampleFilter::CatmullRom,
                                 "Gaussian" => DownsampleFilter::Gaussian,

--- a/crates/mujou-pipeline/src/downsample.rs
+++ b/crates/mujou-pipeline/src/downsample.rs
@@ -16,11 +16,11 @@ use serde::{Deserialize, Serialize};
 /// Resampling filter used when downsampling.
 ///
 /// Ordered from fastest/lowest-quality to slowest/highest-quality,
-/// with a `None` variant to skip downsampling entirely.
+/// with a `Disabled` variant to skip downsampling entirely.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DownsampleFilter {
     /// Disabled: skip downsampling regardless of image size.
-    None,
+    Disabled,
     /// Nearest-neighbor: fastest, blocky artifacts.
     Nearest,
     /// Bilinear interpolation: fast, decent quality.
@@ -42,11 +42,11 @@ impl Default for DownsampleFilter {
 impl DownsampleFilter {
     /// Convert to the `image` crate's `FilterType`.
     ///
-    /// Returns `Option::None` for [`DownsampleFilter::None`] since
+    /// Returns `None` for [`DownsampleFilter::Disabled`] since
     /// there is no corresponding resampling filter.
     const fn to_image_filter(self) -> Option<image::imageops::FilterType> {
         match self {
-            Self::None => Option::None,
+            Self::Disabled => None,
             Self::Nearest => Some(image::imageops::FilterType::Nearest),
             Self::Triangle => Some(image::imageops::FilterType::Triangle),
             Self::CatmullRom => Some(image::imageops::FilterType::CatmullRom),
@@ -59,7 +59,7 @@ impl DownsampleFilter {
 impl fmt::Display for DownsampleFilter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::None => f.write_str("None"),
+            Self::Disabled => f.write_str("Disabled"),
             Self::Nearest => f.write_str("Nearest"),
             Self::Triangle => f.write_str("Triangle"),
             Self::CatmullRom => f.write_str("CatmullRom"),
@@ -162,18 +162,18 @@ mod tests {
     }
 
     #[test]
-    fn none_filter_skips_even_large_image() {
+    fn disabled_filter_skips_even_large_image() {
         let img = test_image(1024, 768);
-        let (result, applied) = downsample(&img, 256, DownsampleFilter::None);
+        let (result, applied) = downsample(&img, 256, DownsampleFilter::Disabled);
         assert!(!applied);
         assert_eq!(result.width(), 1024);
         assert_eq!(result.height(), 768);
     }
 
     #[test]
-    fn none_filter_skips_small_image() {
+    fn disabled_filter_skips_small_image() {
         let img = test_image(100, 80);
-        let (result, applied) = downsample(&img, 256, DownsampleFilter::None);
+        let (result, applied) = downsample(&img, 256, DownsampleFilter::Disabled);
         assert!(!applied);
         assert_eq!(result.width(), 100);
         assert_eq!(result.height(), 80);


### PR DESCRIPTION
## Summary

- Adds a `Disabled` variant to `DownsampleFilter` that skips downsampling entirely, regardless of the `working_resolution` setting
- Useful for working with already-right-sized images, debugging full-resolution pipeline output, or benchmarking without the downsampling variable
- Updated across pipeline core, UI dropdown, and CLI bench tool

## Changes

- **`downsample.rs`**: Added `None` variant to enum, updated `to_image_filter()` to return `Option<FilterType>`, early-return in `downsample()` when filter is `None`, added test
- **`stage_controls.rs`**: Added "None (Disabled)" as the first dropdown option, updated match arms
- **`main.rs` (bench)**: Added `None` to local `Filter` enum and both mapping functions

Closes #85