### PR TITLE
Add sand table upload guidance to export popup

### DIFF
--- a/crates/mujou-io/src/components/export.rs
+++ b/crates/mujou-io/src/components/export.rs
@@ -136,25 +136,8 @@ pub fn ExportPanel(props: ExportPanelProps) -> Element {
                     }
                 }
 
-                // Upload guidance
-                div { class: "mb-5 text-sm text-[var(--text-secondary)]",
-                    p { class: "font-medium text-[var(--text)] mb-1",
-                        "Upload to your table"
-                    }
-                    p {
-                        "Oasis Mini / One: use SVG, upload at "
-                        a {
-                            href: "https://app.grounded.so",
-                            target: "_blank",
-                            rel: "noopener noreferrer",
-                            class: "underline text-[var(--btn-primary)] hover:opacity-80",
-                            "app.grounded.so"
-                        }
-                    }
-                }
-
                 // Action buttons
-                div { class: "flex gap-3",
+                div { class: "flex gap-3 mb-5",
                     button {
                         class: "flex-1 text-sm px-4 py-1.5 rounded bg-[var(--btn-primary)] hover:bg-[var(--btn-primary-hover)] text-white cursor-pointer transition-colors disabled:bg-[var(--btn-disabled)] disabled:text-[var(--text-disabled)] disabled:cursor-not-allowed",
                         disabled: !has_result || !any_selected,
@@ -165,6 +148,23 @@ pub fn ExportPanel(props: ExportPanelProps) -> Element {
                         class: "text-sm px-4 py-1.5 rounded border border-[var(--border)] text-[var(--text)] hover:opacity-80 cursor-pointer transition-colors",
                         onclick: move |_| show.set(false),
                         "Cancel"
+                    }
+                }
+
+                // Upload guidance
+                div { class: "text-sm text-[var(--text-secondary)]",
+                    p { class: "font-medium text-[var(--text)] mb-1",
+                        "Next, upload to your table"
+                    }
+                    p {
+                        "Oasis Mini / One: use SVG, upload at "
+                        a {
+                            href: "https://app.grounded.so",
+                            target: "_blank",
+                            rel: "noopener noreferrer",
+                            class: "underline text-[var(--btn-primary)] hover:opacity-80",
+                            "app.grounded.so"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Adds an always-visible "Upload to your table" guidance section to the export popup, between the format checkboxes and the action buttons
- Starts with Oasis Mini / One: directs users to use SVG format and links to [app.grounded.so](https://app.grounded.so) (opens in a new tab)
- Additional table/device entries can be added incrementally as needed

Closes #42