### PR TITLE
Update downsample defaults: resolution 1000, max 2000, bilinear filter

### DIFF
--- a/crates/mujou-io/src/components/stage_controls.rs
+++ b/crates/mujou-io/src/components/stage_controls.rs
@@ -67,7 +67,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         desc("Max pixel dimension for processing. Lower is faster."),
                         f64::from(value),
                         64.0,
-                        1024.0,
+                        2000.0,
                         1.0,
                         0,
                         move |v: f64| {

--- a/crates/mujou-pipeline/src/mst_join.rs
+++ b/crates/mujou-pipeline/src/mst_join.rs
@@ -197,9 +197,10 @@ const MAX_NN_ITERATIONS: usize = 200;
 /// for R-tree nearest-neighbor queries during MST candidate generation.
 ///
 /// Lower values produce more samples and better MST quality at the cost
-/// of more R-tree queries.  At the default `working_resolution` of 256
-/// this yields ~51 samples across the longest axis, matching the
-/// previous hard-coded divisor of 50.
+/// of more R-tree queries.  At the default `working_resolution` of 1000
+/// this yields ~200 samples across the longest axis.  (The spacing was
+/// originally chosen to give ~51 samples at the former default of 256,
+/// matching the previous hard-coded divisor of 50.)
 const SAMPLE_SPACING_PIXELS: f64 = 5.0;
 
 /// Build an MST connecting all polylines using Kruskal's algorithm with

--- a/crates/mujou-pipeline/src/types.rs
+++ b/crates/mujou-pipeline/src/types.rs
@@ -344,9 +344,9 @@ impl PipelineConfig {
     /// Default edge map inversion state.
     pub const DEFAULT_INVERT: bool = false;
     /// Default working resolution (max dimension after downsampling).
-    pub const DEFAULT_WORKING_RESOLUTION: u32 = 256;
+    pub const DEFAULT_WORKING_RESOLUTION: u32 = 1000;
     /// Default downsample filter.
-    pub const DEFAULT_DOWNSAMPLE_FILTER: DownsampleFilter = DownsampleFilter::Disabled;
+    pub const DEFAULT_DOWNSAMPLE_FILTER: DownsampleFilter = DownsampleFilter::Triangle;
     /// Default MST nearest-neighbour candidate count per sample point.
     pub const DEFAULT_MST_NEIGHBOURS: usize = 100;
     /// Default edge channels (luminance only).
@@ -859,8 +859,8 @@ mod tests {
         assert!(config.circular_mask);
         assert!((config.mask_diameter - 0.75).abs() < f64::EPSILON);
         assert!(!config.invert);
-        assert_eq!(config.working_resolution, 256);
-        assert_eq!(config.downsample_filter, DownsampleFilter::Disabled);
+        assert_eq!(config.working_resolution, 1000);
+        assert_eq!(config.downsample_filter, DownsampleFilter::Triangle);
         assert_eq!(config.mst_neighbours, 100);
         assert_eq!(config.edge_channels, EdgeChannels::default());
         assert!(config.edge_channels.luminance);

--- a/docs/src/project/pipeline.md
+++ b/docs/src/project/pipeline.md
@@ -20,8 +20,8 @@ All subsequent pipeline stages operate at this reduced resolution.
 
 **User parameters:**
 
-- `working_resolution` (u32, default: 256)
-- `downsample_filter` (`DownsampleFilter`, default: `Disabled`)
+- `working_resolution` (u32, default: 1000)
+- `downsample_filter` (`DownsampleFilter`, default: `Triangle`)
 
 ### 3. Gaussian Blur
 


### PR DESCRIPTION
## Summary

- Raise `DEFAULT_WORKING_RESOLUTION` from 256 to 1000 for better out-of-the-box detail retention
- Change `DEFAULT_DOWNSAMPLE_FILTER` from `Disabled` to `Triangle` (bilinear) so downsampling is active by default — this also resolves the inconsistency with `DownsampleFilter`'s own `Default` impl
- Extend resolution slider max from 1024 to 2000 to allow higher-fidelity processing
- Update pipeline documentation, test assertions, and code comments to reflect the new defaults

Closes #108