### PR TITLE
Revise MST neighbours and simplification defaults and slider ranges

### DIFF
--- a/crates/mujou-io/src/components/stage_controls.rs
+++ b/crates/mujou-io/src/components/stage_controls.rs
@@ -324,7 +324,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                         desc("Point reduction strength. Higher means fewer points."),
                         value,
                         0.0,
-                        20.0,
+                        10.0,
                         0.1,
                         1,
                         move |v: f64| {
@@ -372,7 +372,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
                             #[allow(clippy::cast_precision_loss)]
                             { config_slider.mst_neighbours as f64 },
                             1.0,
-                            100.0,
+                            200.0,
                             1.0,
                             0,
                             move |v: f64| {

--- a/crates/mujou-pipeline/src/types.rs
+++ b/crates/mujou-pipeline/src/types.rs
@@ -336,7 +336,7 @@ impl PipelineConfig {
     /// Default Canny slider maximum.
     pub const DEFAULT_CANNY_MAX: f32 = 60.0;
     /// Default RDP simplification tolerance in pixels.
-    pub const DEFAULT_SIMPLIFY_TOLERANCE: f64 = 2.0;
+    pub const DEFAULT_SIMPLIFY_TOLERANCE: f64 = 1.0;
     /// Default circular mask enabled state.
     pub const DEFAULT_CIRCULAR_MASK: bool = true;
     /// Default mask diameter as a fraction of image diagonal.
@@ -348,7 +348,7 @@ impl PipelineConfig {
     /// Default downsample filter.
     pub const DEFAULT_DOWNSAMPLE_FILTER: DownsampleFilter = DownsampleFilter::Triangle;
     /// Default MST nearest-neighbour candidate count per sample point.
-    pub const DEFAULT_MST_NEIGHBOURS: usize = 100;
+    pub const DEFAULT_MST_NEIGHBOURS: usize = 20;
     /// Default edge channels (luminance only).
     pub const DEFAULT_EDGE_CHANNELS: EdgeChannels = EdgeChannels {
         luminance: true,
@@ -854,14 +854,14 @@ mod tests {
         assert!((config.canny_high - 40.0).abs() < f32::EPSILON);
         assert!((config.canny_max - 60.0).abs() < f32::EPSILON);
         assert_eq!(config.contour_tracer, ContourTracerKind::BorderFollowing);
-        assert!((config.simplify_tolerance - 2.0).abs() < f64::EPSILON);
+        assert!((config.simplify_tolerance - 1.0).abs() < f64::EPSILON);
         assert_eq!(config.path_joiner, PathJoinerKind::Mst);
         assert!(config.circular_mask);
         assert!((config.mask_diameter - 0.75).abs() < f64::EPSILON);
         assert!(!config.invert);
         assert_eq!(config.working_resolution, 1000);
         assert_eq!(config.downsample_filter, DownsampleFilter::Triangle);
-        assert_eq!(config.mst_neighbours, 100);
+        assert_eq!(config.mst_neighbours, 20);
         assert_eq!(config.edge_channels, EdgeChannels::default());
         assert!(config.edge_channels.luminance);
         assert!(!config.edge_channels.red);


### PR DESCRIPTION
## Summary

- Lower MST neighbours default from 100 → 20 and expand slider max from 100 → 200, so users have room to adjust in both directions instead of starting pinned at maximum
- Lower simplification tolerance default from 2.0 → 1.0 for better out-of-the-box detail preservation, and reduce slider max from 20.0 → 10.0 since higher values rarely produce useful results
- Update corresponding test assertions for the new default values

Closes #114