### PR TITLE
Rename StageId::Path to StageId::Join

### DIFF
--- a/crates/mujou-io/src/components/filmstrip.rs
+++ b/crates/mujou-io/src/components/filmstrip.rs
@@ -161,7 +161,7 @@ fn render_thumbnail(result: &WorkerResult, stage: StageId, is_dark: bool) -> Ele
             }
         }
 
-        StageId::Path => {
+        StageId::Join => {
             let polyline = &result.joined;
             let w = result.dimensions.width;
             let h = result.dimensions.height;

--- a/crates/mujou-io/src/components/stage_controls.rs
+++ b/crates/mujou-io/src/components/stage_controls.rs
@@ -33,7 +33,7 @@ pub struct StageControlsProps {
 /// - **Edges**: Canny low/high sliders, invert toggle
 /// - **Contours**: contour tracer select
 /// - **Simplified**: simplify tolerance slider
-/// - **Path**: path joiner select
+/// - **Join**: path joiner select
 /// - **Masked**: circular mask toggle, mask diameter slider
 #[component]
 #[allow(clippy::too_many_lines)]
@@ -337,7 +337,7 @@ pub fn StageControls(props: StageControlsProps) -> Element {
             }
         }
 
-        StageId::Path => {
+        StageId::Join => {
             let config_select = config.clone();
             let config_slider = config.clone();
             let is_mst = matches!(config.path_joiner, PathJoinerKind::Mst);

--- a/crates/mujou-io/src/components/stage_preview.rs
+++ b/crates/mujou-io/src/components/stage_preview.rs
@@ -115,7 +115,7 @@ fn render_raster_edges(result: &WorkerResult, visible: bool, is_dark: bool) -> E
     }
 }
 
-/// Render the vector (SVG) preview for Contours, Simplified, Path, or
+/// Render the vector (SVG) preview for Contours, Simplified, Join, or
 /// Masked stages. Returns empty for raster stages.
 fn render_vector_preview(result: &WorkerResult, selected: StageId, w: u32, h: u32) -> Element {
     match selected {
@@ -148,7 +148,7 @@ fn render_vector_preview(result: &WorkerResult, selected: StageId, w: u32, h: u3
             }
         }
 
-        StageId::Path => {
+        StageId::Join => {
             let polyline = &result.joined;
             let view_box = format!("0 0 {w} {h}");
             let d = build_path_data(polyline);

--- a/crates/mujou-io/src/stage.rs
+++ b/crates/mujou-io/src/stage.rs
@@ -28,8 +28,8 @@ pub enum StageId {
     Simplified,
     /// Stage 8: circular mask.
     Masked,
-    /// Stage 9: path joining.
-    Path,
+    /// Stage 9: join (path joining).
+    Join,
 }
 
 impl StageId {
@@ -42,7 +42,7 @@ impl StageId {
         Self::Contours,
         Self::Simplified,
         Self::Masked,
-        Self::Path,
+        Self::Join,
     ];
 
     /// Full display label for the stage.
@@ -55,7 +55,7 @@ impl StageId {
             Self::Edges => "Edges",
             Self::Contours => "Contours",
             Self::Simplified => "Simplified",
-            Self::Path => "Path",
+            Self::Join => "Join",
             Self::Masked => "Masked",
         }
     }
@@ -80,7 +80,7 @@ impl StageId {
             5 => Some(Self::Contours),     // ContoursTraced
             6 => Some(Self::Simplified),   // Simplified
             7 => Some(Self::Masked),       // Masked
-            8 => Some(Self::Path),         // Joined
+            8 => Some(Self::Join),         // Joined
             _ => None,
         }
     }
@@ -96,7 +96,7 @@ impl StageId {
             Self::Contours => "Cont",
             Self::Simplified => "Simp",
             Self::Masked => "Mask",
-            Self::Path => "Path",
+            Self::Join => "Join",
         }
     }
 }


### PR DESCRIPTION
## Summary

- Renames `StageId::Path` to `StageId::Join` across the codebase (enum variant, labels, match arms, doc comments)
- The stage performs path **joining** (combining simplified polylines into a single continuous path via MST traversal), so "Join" better reflects its purpose and aligns with the internal pipeline name `Joined`
- 11 edits across 4 files in `crates/mujou-io/`

Closes #125