### PR TITLE
Fix edge thumbnails/preview not updating on theme toggle

### DIFF
--- a/crates/mujou-io/src/components/filmstrip.rs
+++ b/crates/mujou-io/src/components/filmstrip.rs
@@ -28,6 +28,10 @@ pub struct FilmstripProps {
     selected: StageId,
     /// Callback fired when a stage tile is clicked.
     on_select: EventHandler<StageId>,
+    /// Whether the dark theme is active.  Passed as a prop (rather than
+    /// read from context) so the `PartialEq` memoisation check captures
+    /// theme changes and triggers a re-render.
+    is_dark: bool,
 }
 
 impl PartialEq for FilmstripProps {
@@ -37,7 +41,7 @@ impl PartialEq for FilmstripProps {
             (None, None) => true,
             _ => false,
         };
-        results_eq && self.selected == other.selected
+        results_eq && self.selected == other.selected && self.is_dark == other.is_dark
     }
 }
 
@@ -49,7 +53,7 @@ impl PartialEq for FilmstripProps {
 /// background are shown for each stage.
 #[component]
 pub fn Filmstrip(props: FilmstripProps) -> Element {
-    let is_dark: Signal<bool> = use_context();
+    let is_dark = props.is_dark;
 
     rsx! {
         div {
@@ -58,7 +62,7 @@ pub fn Filmstrip(props: FilmstripProps) -> Element {
             class: "flex flex-nowrap overflow-x-auto gap-2 py-2 scrollbar-thin flex-shrink-0",
 
             for stage in StageId::ALL {
-                {render_tile(props.result.as_deref(), stage, props.selected == stage, &props.on_select, is_dark())}
+                {render_tile(props.result.as_deref(), stage, props.selected == stage, &props.on_select, is_dark)}
             }
         }
     }

--- a/crates/mujou-io/src/components/stage_preview.rs
+++ b/crates/mujou-io/src/components/stage_preview.rs
@@ -34,6 +34,10 @@ pub struct StagePreviewProps {
     result: Option<Rc<WorkerResult>>,
     /// Which stage to display.
     selected: StageId,
+    /// Whether the dark theme is active.  Passed as a prop (rather than
+    /// read from context) so the `PartialEq` memoisation check captures
+    /// theme changes and triggers a re-render.
+    is_dark: bool,
 }
 
 impl PartialEq for StagePreviewProps {
@@ -43,7 +47,7 @@ impl PartialEq for StagePreviewProps {
             (None, None) => true,
             _ => false,
         };
-        results_eq && self.selected == other.selected
+        results_eq && self.selected == other.selected && self.is_dark == other.is_dark
     }
 }
 
@@ -75,9 +79,7 @@ pub fn StagePreview(props: StagePreviewProps) -> Element {
     let selected = props.selected;
     let w = result.dimensions.width;
     let h = result.dimensions.height;
-
-    // Reactive theme signal provided by the app root.
-    let is_dark: Signal<bool> = use_context();
+    let is_dark = props.is_dark;
 
     // Diagnostic overlay toggle provided by the app root.
     let show_diagnostics: Signal<bool> = use_context();
@@ -89,7 +91,7 @@ pub fn StagePreview(props: StagePreviewProps) -> Element {
         {render_raster_img(result.original_url.url(), "Original", selected == StageId::Original)}
         {render_raster_img(result.downsampled_url.url(), "Downsampled", selected == StageId::Downsampled)}
         {render_raster_img(result.blur_url.url(), "Blur", selected == StageId::Blur)}
-        {render_raster_edges(result, selected == StageId::Edges, is_dark())}
+        {render_raster_edges(result, selected == StageId::Edges, is_dark)}
 
         // Vector stages — conditionally rendered (SVG is instant).
         {render_vector_preview(result, selected, w, h, show_diagnostics())}

--- a/crates/mujou/src/main.rs
+++ b/crates/mujou/src/main.rs
@@ -560,6 +560,7 @@ fn app() -> Element {
                                 StagePreview {
                                     result: result(),
                                     selected: selected_stage(),
+                                    is_dark: is_dark(),
                                 }
                             }
 
@@ -646,6 +647,7 @@ fn app() -> Element {
                             result: result(),
                             selected: selected_stage(),
                             on_select: on_stage_select,
+                            is_dark: is_dark(),
                         }
 
                         // Per-stage controls with copy/paste config buttons


### PR DESCRIPTION
## Summary

- **Bug:** Edge thumbnails and preview didn't update when toggling light/dark theme — a pipeline retrigger was required to see correct themed edges.
- **Root cause:** Dioxus 0.7.3 signal subscriptions are lost between renders. When `is_dark.set()` is called from the JS theme-toggle callback, the signal has zero subscribers, so `StagePreview` and `Filmstrip` never re-render.
- **Fix:** Thread `is_dark: bool` as a prop to `StagePreview` and `Filmstrip` instead of reading from context via `use_context::<Signal<bool>>()`. The parent `app()` reads the signal (maintaining its subscription), re-renders on change, and passes the new value as props where the `PartialEq` check detects the change and triggers child re-renders.

## Changes

- `crates/mujou-io/src/components/stage_preview.rs` — Added `is_dark: bool` to `StagePreviewProps` with `PartialEq`; replaced `use_context::<Signal<bool>>()` with `props.is_dark`
- `crates/mujou-io/src/components/filmstrip.rs` — Added `is_dark: bool` to `FilmstripProps` with `PartialEq`; replaced `use_context::<Signal<bool>>()` with `props.is_dark`
- `crates/mujou/src/main.rs` — Pass `is_dark: is_dark()` to both component invocations

## Verification

- `dx build --package mujou --platform web` succeeds
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --check` clean
- All 312 tests pass (`cargo nextest run --all-features`)
- Browser-tested: toggling system → light → dark → system, edges preview and thumbnail blob URLs switch immediately between light and dark variants without pipeline retrigger