### PR TITLE
Fix renovatebot/github-action tag to full semver

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,6 +18,6 @@ jobs:
           app-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
 
-      - uses: renovatebot/github-action@v46
+      - uses: renovatebot/github-action@v46.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Fix `renovatebot/github-action@v46` → `renovatebot/github-action@v46.1.1`

The `renovatebot/github-action` does not publish rolling major-version tags (no `v46`). Only full semver tags like `v46.1.1` are available. The Renovate workflow was failing with:

> Unable to resolve action `renovatebot/github-action@v46`, unable to find version `v46`

Renovate's `github-actions` manager will keep this version updated going forward.

**Failed run:** https://github.com/altendky/mujou/actions/runs/22283307185/job/64457347929