### PR TITLE
test: switch CI runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/check-pages-ips.yml
+++ b/.github/workflows/check-pages-ips.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   check:
     name: Check IPs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     name: all
     if: always()
     needs: [mise, pre-commit, rust, wasm, coverage]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: re-actors/alls-green@release/v1
         with:

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/reflow-coverage.yml
+++ b/.github/workflows/reflow-coverage.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/reflow-mise.yml
+++ b/.github/workflows/reflow-mise.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Lockfile
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/reflow-pre-commit.yml
+++ b/.github/workflows/reflow-pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Pre-commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/reflow-rust.yml
+++ b/.github/workflows/reflow-rust.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -32,7 +32,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/reflow-wasm.yml
+++ b/.github/workflows/reflow-wasm.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: WASM Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   renovate:
     name: Renovate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
         id: app-token


### PR DESCRIPTION
## Summary

- Switch all GitHub Actions runners from `ubuntu-latest` to `ubuntu-22.04`

Test PR for a friend.