### PR TITLE
Add codecov.yml configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%  # Ratchet - fail if coverage drops more than 2%
+    patch:
+      default:
+        target: 100%  # New code must be fully covered
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: true
+
+flags:
+  rust:
+    paths:
+      - crates/
+    carryforward: true
+
+component_management:
+  individual_components:
+    - component_id: rust
+      name: Rust
+      paths:
+        - crates/**


### PR DESCRIPTION
## Summary

- Add Codecov configuration to enforce coverage standards on PRs
- Configure 2% threshold for project coverage (ratchet)
- Require 100% coverage on new code (patch)
- Set up Rust flag and component for `crates/` paths

Closes #211