### PR TITLE
Add Mergify configuration for merge queue and Renovate auto-approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,22 @@
+queue_rules:
+  - name: default
+    autoqueue: true
+    branch_protection_injection_mode: merge
+    queue_conditions:
+      - label = enqueue
+      - base = main
+      - "#approved-reviews-by >= 1"
+    merge_method: merge
+    checks_timeout: 90 min
+    max_checks_retries: 2
+
+merge_queue:
+  max_parallel_checks: 1
+
+pull_request_rules:
+  - name: Automatically approve Renovate PRs
+    conditions:
+      - author = altendky-renovate[bot]
+    actions:
+      review:
+        type: APPROVE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
       - id: actionlint
         args: [-verbose]
 
+  - repo: https://github.com/Mergifyio/mergify-pre-commit
+    rev: 1.1.0
+    hooks:
+      - id: validate-mergify-config
+
   - repo: local
     hooks:
       - id: mise-lock


### PR DESCRIPTION
## Summary

- Add `.mergify.yml` with merge queue configuration (autoqueue, branch protection injection, checks timeout, retry on failure)
- Add `validate-mergify-config` pre-commit hook to validate Mergify configuration
- Configure automatic approval for Renovate PRs to reduce manual approval burden

**Note:** The pre-commit hook (v1.1.0) uses an outdated schema that doesn't recognize `max_checks_retries`, so it will fail locally. Mergify's server-side validation handles this correctly.

Closes #213