### PR TITLE
Wire up Codecov upload in reflow-coverage.yml

### DIFF
--- a/.github/workflows/reflow-coverage.yml
+++ b/.github/workflows/reflow-coverage.yml
@@ -7,6 +7,8 @@ jobs:
   check:
     name: Coverage
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -21,7 +23,13 @@ jobs:
         with:
           target: wasm32-unknown-unknown
 
-      # TODO: Upload lcov.info to Codecov once coverage reporting is set up.
-      #   See: docs/src/project/open-questions.md (Deferred > Infrastructure > Coverage reporting)
       - name: Generate coverage
         run: cargo llvm-cov nextest --all-features --workspace --no-tests=warn --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: lcov.info
+          flags: rust
+          fail_ci_if_error: true

--- a/docs/src/project/open-questions.md
+++ b/docs/src/project/open-questions.md
@@ -47,6 +47,6 @@ Items to address after MVP:
 
 - [ ] GitHub Actions CI -- Linting, testing, WASM build, deployment
 - [ ] Release workflow -- Automated static site deployment on tag
-- [ ] Coverage reporting -- Codecov integration
+- [x] Coverage reporting -- Codecov integration
 - [ ] Auto-deploy on merge to main -- Currently deploy is manual (`workflow_dispatch`). Consider triggering on push to `main` once the workflow is proven reliable. If enabled, consider whether deploy should be gated on CI passing (via `workflow_run` trigger or a combined workflow) to prevent deploying broken builds.
 - [ ] PR preview deploys -- GitHub Pages does not support deploy previews from PRs natively. Options include external services (surge.sh, Cloudflare Pages for previews only), downloadable build artifacts for manual review, or no previews (rely on local `dx serve`). Revisit if reviewing UI changes from PRs becomes painful.


### PR DESCRIPTION
## Summary

- Add codecov-action step to upload `lcov.info` coverage data after generation
- Use `rust` flag to match `codecov.yml` configuration
- Mark coverage reporting as done in open-questions.md

Closes #212