### PR TITLE
Change alls-green gate condition from always() to !cancelled()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
   all:
     name: all
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [mise, pre-commit, rust, wasm, coverage]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Replace `if: always()` with `if: ${{ !cancelled() }}` on the `all` gate job in `ci.yml`
- `always()` runs the gate even when jobs are manually cancelled, which can report a misleading green status
- `!cancelled()` correctly fails the gate when upstream jobs are cancelled, while still running on success or failure

Closes #235